### PR TITLE
Fix lint warnings

### DIFF
--- a/calc_times_test.go
+++ b/calc_times_test.go
@@ -1,28 +1,24 @@
-
 package main
 
-
 import (
-
-    "testing"
-    "time"
+	"testing"
+	"time"
 )
-
 
 func TestCalcTimes(t *testing.T) {
 
-    base_time := time.Date(2016, time.April, 10, 8, 0, 0, 0, time.Local)
+	baseTime := time.Date(2016, time.April, 10, 8, 0, 0, 0, time.Local)
 
-    var first_time, second_time, third_time, fourth_time time.Time
-    calcTimes(&base_time, &first_time, &second_time, &third_time, &fourth_time)
+	var firstTime, secondTime, thirdTime, fourthTime time.Time
+	calcTimes(&baseTime, &firstTime, &secondTime, &thirdTime, &fourthTime)
 
-    if first_time.Hour() != 23 {
-        t.Fatal("First time shoulb be 23, got %d", first_time.Hour())
-    } else if second_time.Hour() != 00 {
-        t.Fatal("Second time shoulb be 00, got %d", second_time.Hour())
-    } else if third_time.Hour() != 2 {
-        t.Fatal("Third time shoulb be 2, got %d", third_time.Hour())
-    } else if fourth_time.Hour() != 3 {
-        t.Fatal("Fourth time shoulb be 3, got %d", fourth_time.Hour())
-    }
+	if firstTime.Hour() != 23 {
+		t.Fatalf("First time shoulb be 23, got %d", firstTime.Hour())
+	} else if secondTime.Hour() != 00 {
+		t.Fatalf("Second time shoulb be 00, got %d", secondTime.Hour())
+	} else if thirdTime.Hour() != 2 {
+		t.Fatalf("Third time shoulb be 2, got %d", thirdTime.Hour())
+	} else if fourthTime.Hour() != 3 {
+		t.Fatalf("Fourth time shoulb be 3, got %d", fourthTime.Hour())
+	}
 }

--- a/format_and_print_test.go
+++ b/format_and_print_test.go
@@ -1,27 +1,23 @@
-
 package main
 
-
 import (
-
-    "testing"
-    "time"
+	"testing"
+	"time"
 )
-
 
 func TestFormatAndPrint(t *testing.T) {
 
-    base_time := time.Date(2016, time.April, 10, 8, 0, 0, 0, time.Local)
+	baseTime := time.Date(2016, time.April, 10, 8, 0, 0, 0, time.Local)
 
-    first_time := base_time.Add(-540 * time.Minute)
-    second_time := base_time.Add(-450 * time.Minute)
-    third_time := base_time.Add(-360 * time.Minute)
-    fourth_time := base_time.Add(-270 * time.Minute)
+	firstTime := baseTime.Add(-540 * time.Minute)
+	secondTime := baseTime.Add(-450 * time.Minute)
+	thirdTime := baseTime.Add(-360 * time.Minute)
+	fourthTime := baseTime.Add(-270 * time.Minute)
 
-    formatAndPrint(&base_time, &first_time, &second_time,
-                   &third_time, &fourth_time)
-    // Output:
-    // To wake up at 8:00 AM, you should sleep at: 11:00 PM
-    //
-    // Also at: 12:30 AM | 2:00 AM | 3:30 AM
+	formatAndPrint(&baseTime, &firstTime, &secondTime,
+		&thirdTime, &fourthTime)
+	// Output:
+	// To wake up at 8:00 AM, you should sleep at: 11:00 PM
+	//
+	// Also at: 12:30 AM | 2:00 AM | 3:30 AM
 }

--- a/is_morning_test.go
+++ b/is_morning_test.go
@@ -1,33 +1,26 @@
 package main
 
-
 import (
-
-    "testing"
+	"testing"
 )
-
 
 func TestIsMorningTrue(t *testing.T) {
 
-    if !isMorning("AM") {
-        t.Fatal("Expected isMorning to true")
-    }
+	if !isMorning("AM") {
+		t.Fatal("Expected isMorning to true")
+	}
 }
-
-
 
 func TestIsMorningFalse(t *testing.T) {
 
-    if isMorning("PM") {
-        t.Fatal("Expected isMorning to false")
-    }
+	if isMorning("PM") {
+		t.Fatal("Expected isMorning to false")
+	}
 }
-
-
 
 func TestIsMorningFalseWhenDurationIsInvalid(t *testing.T) {
 
-    if isMorning("MM") {
-        t.Fatal("Expected isMorning to false")
-    }
+	if isMorning("MM") {
+		t.Fatal("Expected isMorning to false")
+	}
 }

--- a/parse_options_test.go
+++ b/parse_options_test.go
@@ -1,129 +1,120 @@
-
 package main
 
-
 import (
-    "testing"
-    "os"
-    "flag"
+	"flag"
+	"os"
+	"testing"
 )
-
 
 // Reset CommandLine for each test from flags parsing
 func ResetCommandLineFlags() {
 
-    flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 }
-
 
 func TestDefaultCommandlineOptionsValues(t *testing.T) {
 
-    defer ResetCommandLineFlags()
+	defer ResetCommandLineFlags()
 
-    var hours int
-    var minutes int
-    var period string
+	var hours int
+	var minutes int
+	var period string
 
-    parseOptions(&hours, &minutes, &period)
+	parseOptions(&hours, &minutes, &period)
 
-    if hours != 8 {
-        t.Fatal("Default hour must be 8, got ", hours)
-    } else if minutes != 0 {
-        t.Fatal("Default minute must be 0, got ", minutes)
-    } else if period != "AM" {
-        t.Fatal("Default period must be AM, got ", period)
-    }
+	if hours != 8 {
+		t.Fatal("Default hour must be 8, got ", hours)
+	} else if minutes != 0 {
+		t.Fatal("Default minute must be 0, got ", minutes)
+	} else if period != "AM" {
+		t.Fatal("Default period must be AM, got ", period)
+	}
 }
-
 
 func TestHourInputOption(t *testing.T) {
 
-    defer ResetCommandLineFlags()
+	defer ResetCommandLineFlags()
 
-    os.Args = []string{"cmd", "-h", "10"}
+	os.Args = []string{"cmd", "-h", "10"}
 
-    var hours int
-    var minutes int
-    var period string
+	var hours int
+	var minutes int
+	var period string
 
-    parseOptions(&hours, &minutes, &period)
+	parseOptions(&hours, &minutes, &period)
 
-    if hours != 10 {
-        t.Fatal("wake up hour must be 10, got ", hours)
-    }
+	if hours != 10 {
+		t.Fatal("wake up hour must be 10, got ", hours)
+	}
 }
-
 
 func TestMinuteInputOption(t *testing.T) {
 
-    defer ResetCommandLineFlags()
+	defer ResetCommandLineFlags()
 
-    os.Args = []string{"cmd", "-m", "15"}
+	os.Args = []string{"cmd", "-m", "15"}
 
-    var hours int
-    var minutes int
-    var period string
+	var hours int
+	var minutes int
+	var period string
 
-    parseOptions(&hours, &minutes, &period)
+	parseOptions(&hours, &minutes, &period)
 
-    if minutes != 15 {
-        t.Fatal("wake up minutes must be 15, got ", minutes)
-    }
+	if minutes != 15 {
+		t.Fatal("wake up minutes must be 15, got ", minutes)
+	}
 }
-
 
 func TestPeriodInputOption(t *testing.T) {
 
-    defer ResetCommandLineFlags()
+	defer ResetCommandLineFlags()
 
-    os.Args = []string{"cmd", "-p", "pm"}
+	os.Args = []string{"cmd", "-p", "pm"}
 
-    var hours int
-    var minutes int
-    var period string
+	var hours int
+	var minutes int
+	var period string
 
-    parseOptions(&hours, &minutes, &period)
+	parseOptions(&hours, &minutes, &period)
 
-    if period != "PM" {
-        t.Fatal("wake up period must be PM, got ", period)
-    }
+	if period != "PM" {
+		t.Fatal("wake up period must be PM, got ", period)
+	}
 }
-
 
 func TestWrongPeriodInputOption(t *testing.T) {
 
-    defer ResetCommandLineFlags()
+	defer ResetCommandLineFlags()
 
-    os.Args = []string{"cmd", "-p", "wrong"}
+	os.Args = []string{"cmd", "-p", "wrong"}
 
-    var hours int
-    var minutes int
-    var period string
+	var hours int
+	var minutes int
+	var period string
 
-    parseOptions(&hours, &minutes, &period)
+	parseOptions(&hours, &minutes, &period)
 
-    if period != "AM" {
-        t.Fatal("wake up period must be PM, got ", period)
-    }
+	if period != "AM" {
+		t.Fatal("wake up period must be PM, got ", period)
+	}
 }
-
 
 func TestUsageFunctionCallWhenThereIsAnInvalidOption(t *testing.T) {
 
-    defer ResetCommandLineFlags()
+	defer ResetCommandLineFlags()
 
-    os.Args = []string{"cmd", "-wrong"}
+	os.Args = []string{"cmd", "-wrong"}
 
-    var hours int
-    var minutes int
-    var period string
+	var hours int
+	var minutes int
+	var period string
 
-    var called bool = false
-    flag.Usage = func () { called = true }
+	var called = false
+	flag.Usage = func() { called = true }
 
-    parseOptions(&hours, &minutes, &period)
+	parseOptions(&hours, &minutes, &period)
 
-    if !called {
-        t.Fatal("Usage function not called")
-    }
+	if !called {
+		t.Fatal("Usage function not called")
+	}
 }


### PR DESCRIPTION
This PR contains the following changes:
- Running `gofmt` on all go source
- Fixing lint errors detected by [gometalinter](https://github.com/alecthomas/gometalinter)
- remove underscores from variable names
- make `package main` constants unexported
- using t.Fatalf when formatting specifiers are used 
